### PR TITLE
Fix to properly ignore redirects for 2 factor auth

### DIFF
--- a/lib/local-oauth.js
+++ b/lib/local-oauth.js
@@ -85,14 +85,19 @@ exports.oauth = class Oauth_export{
             });
 
             window.webContents.on('will-navigate', function (event, url) {
-                localoauth.get_auth_tokens(url).then((result)=>{
-                    resolve(result);
-                }).catch(()=>{
-                    window.show();
+                if (url.indexOf('oauth_token=') >= 0 && url.indexOf('oauth_verifier=') >= 0) {
                     localoauth.get_auth_tokens(url).then((result)=>{
                         resolve(result);
-                    }).catch((error)=>{reject(error);});
-                });
+                    }).catch(()=>{
+                        window.show();
+                        localoauth.get_auth_tokens(url).then((result)=>{
+                            resolve(result);
+                        }).catch((error)=>{
+                            console.log('failing here')
+                            reject(error);
+                        });
+                    });
+                }
             });
 
             localoauth.get_request_tokens().then(()=>{


### PR DESCRIPTION
The original code was jumping to request the auth tokens too early when the logging-in user had 2-factor-authentication enabled. I've added a check to make sure the URL being loaded has the OAuth parameters needed to complete the authorization. I'm also happy to refactor this to use URL parsing instead of the simple string search used here. 